### PR TITLE
Next.js v15.4.3 upgrade

### DIFF
--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -13,14 +13,14 @@
   },
   "dependencies": {
     "@repo/ui": "workspace:*",
-    "next": "^15.4.2",
+    "next": "^15.4.3",
     "react": "^19.1.0",
     "react-dom": "^19.1.0"
   },
   "devDependencies": {
     "@repo/config": "workspace:*",
     "@repo/next-fonts": "workspace:*",
-    "@types/node": "^24.0.14",
+    "@types/node": "^24.1.0",
     "@types/react": "^19.1.8",
     "@types/react-dom": "^19.1.6",
     "eslint": "^9.31.0",

--- a/apps/emergence/package.json
+++ b/apps/emergence/package.json
@@ -19,13 +19,13 @@
     "@mui/material": "^7.2.0",
     "@mui/material-nextjs": "^7.2.0",
     "@repo/mui": "workspace:*",
-    "next": "^15.4.2",
+    "next": "^15.4.3",
     "react": "^19.1.0",
     "react-dom": "^19.1.0"
   },
   "devDependencies": {
     "@repo/config": "workspace:*",
-    "@types/node": "^24.0.14",
+    "@types/node": "^24.1.0",
     "@types/react": "^19.1.8",
     "@types/react-dom": "^19.1.6",
     "eslint": "^9.31.0",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -13,14 +13,14 @@
   },
   "dependencies": {
     "@repo/ui": "workspace:*",
-    "next": "^15.4.2",
+    "next": "^15.4.3",
     "react": "^19.1.0",
     "react-dom": "^19.1.0"
   },
   "devDependencies": {
     "@repo/config": "workspace:*",
     "@repo/next-fonts": "workspace:*",
-    "@types/node": "^24.0.14",
+    "@types/node": "^24.1.0",
     "@types/react": "^19.1.8",
     "@types/react-dom": "^19.1.6",
     "eslint": "^9.31.0",

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -18,7 +18,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.31.0",
-    "@next/eslint-plugin-next": "^15.3.0",
+    "@next/eslint-plugin-next": "^15.4.3",
     "eslint": "^9.31.0",
     "eslint-config-prettier": "^10.1.8",
     "eslint-plugin-jsonc": "^2.20.1",
@@ -26,10 +26,10 @@
     "eslint-plugin-prettier": "^5.5.3",
     "eslint-plugin-react": "^7.37.5",
     "eslint-plugin-react-hooks": "^5.2.0",
-    "eslint-plugin-turbo": "^2.5.0",
+    "eslint-plugin-turbo": "^2.5.5",
     "globals": "^16.3.0",
-    "jiti": "^2.4.2",
+    "jiti": "^2.5.0",
     "typescript": "^5.8.3",
-    "typescript-eslint": "^8.36.0"
+    "typescript-eslint": "^8.38.0"
   }
 }

--- a/packages/mui/package.json
+++ b/packages/mui/package.json
@@ -20,13 +20,13 @@
     "@mui/icons-material": "^7.2.0",
     "@mui/material": "^7.2.0",
     "@mui/material-nextjs": "^7.2.0",
-    "next": "^15.4.2",
+    "next": "^15.4.3",
     "react": "^19.1.0",
     "react-dom": "^19.1.0"
   },
   "devDependencies": {
     "@repo/config": "workspace:*",
-    "@types/node": "^24.0.14",
+    "@types/node": "^24.1.0",
     "@types/react": "^19.1.8",
     "@types/react-dom": "^19.1.6",
     "eslint": "^9.31.0",

--- a/packages/next-fonts/package.json
+++ b/packages/next-fonts/package.json
@@ -13,13 +13,13 @@
     "react:component:generate": "turbo gen react-component"
   },
   "dependencies": {
-    "next": "^15.4.2",
+    "next": "^15.4.3",
     "react": "^19.1.0",
     "react-dom": "^19.1.0"
   },
   "devDependencies": {
     "@repo/config": "workspace:*",
-    "@types/node": "^24.0.14",
+    "@types/node": "^24.1.0",
     "@types/react": "^19.1.8",
     "@types/react-dom": "^19.1.6",
     "eslint": "^9.31.0",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -18,7 +18,7 @@
   },
   "devDependencies": {
     "@repo/config": "workspace:*",
-    "@types/node": "^24.0.14",
+    "@types/node": "^24.1.0",
     "@types/react": "^19.1.8",
     "@types/react-dom": "^19.1.6",
     "eslint": "^9.31.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,7 +18,7 @@ importers:
         specifier: workspace:*
         version: link:../../packages/ui
       next:
-        specifier: ^15.4.2
+        specifier: ^15.4.3
         version: 15.4.3(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       react:
         specifier: ^19.1.0
@@ -34,7 +34,7 @@ importers:
         specifier: workspace:*
         version: link:../../packages/next-fonts
       '@types/node':
-        specifier: ^24.0.14
+        specifier: ^24.1.0
         version: 24.1.0
       '@types/react':
         specifier: ^19.1.8
@@ -73,7 +73,7 @@ importers:
         specifier: workspace:*
         version: link:../../packages/mui
       next:
-        specifier: ^15.4.2
+        specifier: ^15.4.3
         version: 15.4.3(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       react:
         specifier: ^19.1.0
@@ -86,7 +86,7 @@ importers:
         specifier: workspace:*
         version: link:../../packages/config
       '@types/node':
-        specifier: ^24.0.14
+        specifier: ^24.1.0
         version: 24.1.0
       '@types/react':
         specifier: ^19.1.8
@@ -107,7 +107,7 @@ importers:
         specifier: workspace:*
         version: link:../../packages/ui
       next:
-        specifier: ^15.4.2
+        specifier: ^15.4.3
         version: 15.4.3(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       react:
         specifier: ^19.1.0
@@ -123,7 +123,7 @@ importers:
         specifier: workspace:*
         version: link:../../packages/next-fonts
       '@types/node':
-        specifier: ^24.0.14
+        specifier: ^24.1.0
         version: 24.1.0
       '@types/react':
         specifier: ^19.1.8
@@ -144,7 +144,7 @@ importers:
         specifier: ^9.31.0
         version: 9.31.0
       '@next/eslint-plugin-next':
-        specifier: ^15.3.0
+        specifier: ^15.4.3
         version: 15.4.3
       eslint:
         specifier: ^9.31.0
@@ -168,19 +168,19 @@ importers:
         specifier: ^5.2.0
         version: 5.2.0(eslint@9.31.0(jiti@2.5.0))
       eslint-plugin-turbo:
-        specifier: ^2.5.0
+        specifier: ^2.5.5
         version: 2.5.5(eslint@9.31.0(jiti@2.5.0))(turbo@2.5.5)
       globals:
         specifier: ^16.3.0
         version: 16.3.0
       jiti:
-        specifier: ^2.4.2
+        specifier: ^2.5.0
         version: 2.5.0
       typescript:
         specifier: ^5.8.3
         version: 5.8.3
       typescript-eslint:
-        specifier: ^8.36.0
+        specifier: ^8.38.0
         version: 8.38.0(eslint@9.31.0(jiti@2.5.0))(typescript@5.8.3)
 
   packages/mui:
@@ -204,7 +204,7 @@ importers:
         specifier: ^7.2.0
         version: 7.2.0(@emotion/cache@11.14.0)(@emotion/react@11.14.0(@types/react@19.1.8)(react@19.1.0))(@types/react@19.1.8)(next@15.4.3(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react@19.1.0)
       next:
-        specifier: ^15.4.2
+        specifier: ^15.4.3
         version: 15.4.3(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       react:
         specifier: ^19.1.0
@@ -217,7 +217,7 @@ importers:
         specifier: workspace:*
         version: link:../config
       '@types/node':
-        specifier: ^24.0.14
+        specifier: ^24.1.0
         version: 24.1.0
       '@types/react':
         specifier: ^19.1.8
@@ -235,7 +235,7 @@ importers:
   packages/next-fonts:
     dependencies:
       next:
-        specifier: ^15.4.2
+        specifier: ^15.4.3
         version: 15.4.3(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       react:
         specifier: ^19.1.0
@@ -248,7 +248,7 @@ importers:
         specifier: workspace:*
         version: link:../config
       '@types/node':
-        specifier: ^24.0.14
+        specifier: ^24.1.0
         version: 24.1.0
       '@types/react':
         specifier: ^19.1.8
@@ -276,7 +276,7 @@ importers:
         specifier: workspace:*
         version: link:../config
       '@types/node':
-        specifier: ^24.0.14
+        specifier: ^24.1.0
         version: 24.1.0
       '@types/react':
         specifier: ^19.1.8


### PR DESCRIPTION
## Dependencies upgraded

* next@^15.4.3

### Development
* @next/eslint-plugin-next@^15.4.3
* @types/node@^24.1.0
* eslint-plugin-turbo@^2.5.5
* jiti@^2.5.0
* typescript-eslint@^8.38.0