### PR TITLE
`import-x`: No duplicate import paths

### DIFF
--- a/packages/config/src/eslint/base/importX.ts
+++ b/packages/config/src/eslint/base/importX.ts
@@ -1,7 +1,6 @@
 import parser from '@typescript-eslint/parser'
 import { importX as importXPlugin } from 'eslint-plugin-import-x'
-import { config } from 'typescript-eslint'
-import { type ConfigArray } from 'typescript-eslint'
+import { config, type ConfigArray } from 'typescript-eslint'
 
 const {
   flatConfigs: { recommended, typescript },


### PR DESCRIPTION
`import-x/no-duplicates` set to the following behavior:

## Failure ❌

```typescript
import { config } from 'typescript-eslint'
import { type ConfigArray } from 'typescript-eslint'
```

## Success ✅

```typescript
import { config, type ConfigArray } from 'typescript-eslint'
```