### PR TITLE
ESLint `defineConfig` migration

### DIFF
--- a/packages/config/src/eslint/base/base.ts
+++ b/packages/config/src/eslint/base/base.ts
@@ -1,4 +1,5 @@
-import { config, type ConfigArray } from 'typescript-eslint'
+import { type Linter } from 'eslint'
+import { defineConfig } from 'eslint/config'
 import { globalIgnores } from './globalIgnores.js'
 import { javaScript } from './javaScript.js'
 import { json } from './json.js'
@@ -8,7 +9,9 @@ import { prettier } from './prettier.js'
 import { turbo } from './turbo.js'
 import { typeScript } from './typeScript/typeScript.js'
 
-export const base: ConfigArray = config([
+export type Config = Linter.Config
+
+export const base = defineConfig([
   ...javaScript,
   ...typeScript,
   ...noUnsanitized,
@@ -17,4 +20,4 @@ export const base: ConfigArray = config([
   ...onlyWarn,
   ...globalIgnores,
   ...prettier,
-])
+]) satisfies Config[]

--- a/packages/config/src/eslint/base/globalIgnores.ts
+++ b/packages/config/src/eslint/base/globalIgnores.ts
@@ -1,8 +1,9 @@
 import { resolve } from 'node:path'
 import { cwd } from 'node:process'
 import { includeIgnoreFile } from '@eslint/compat'
-import { config, type ConfigArray } from 'typescript-eslint'
+import { defineConfig } from 'eslint/config'
+import { type Config } from './base.js'
 
-export const globalIgnores: ConfigArray = config([
+export const globalIgnores = defineConfig([
   includeIgnoreFile(resolve(cwd(), '../../.gitignore')),
-])
+]) satisfies Config[]

--- a/packages/config/src/eslint/base/javaScript.ts
+++ b/packages/config/src/eslint/base/javaScript.ts
@@ -1,7 +1,8 @@
 import { configs as jsConfigs } from '@eslint/js'
-import { config, type ConfigArray } from 'typescript-eslint'
+import { defineConfig } from 'eslint/config'
+import { type Config } from './base.js'
 
-export const javaScript: ConfigArray = config([
+export const javaScript = defineConfig([
   jsConfigs.recommended,
   {
     ignores: ['**/*.json'],
@@ -9,4 +10,4 @@ export const javaScript: ConfigArray = config([
       'sort-keys': ['error', 'asc'],
     },
   },
-])
+]) satisfies Config[]

--- a/packages/config/src/eslint/base/json.ts
+++ b/packages/config/src/eslint/base/json.ts
@@ -1,8 +1,9 @@
+import { defineConfig } from 'eslint/config'
 import { configs } from 'eslint-plugin-jsonc'
-import { config, type ConfigArray } from 'typescript-eslint'
+import { type Config } from './base.js'
 
-export const json: ConfigArray = config([
+export const json = defineConfig([
   ...configs['flat/base'],
   ...configs['flat/recommended-with-json'],
   ...configs['flat/prettier'],
-])
+]) satisfies Config[]

--- a/packages/config/src/eslint/base/noUnsanitized.ts
+++ b/packages/config/src/eslint/base/noUnsanitized.ts
@@ -1,8 +1,9 @@
+import { defineConfig } from 'eslint/config'
 // @ts-expect-error -- untyped dependency
 import { configs } from 'eslint-plugin-no-unsanitized'
-import { config, type ConfigArray } from 'typescript-eslint'
+import { type Config } from './base.js'
 
 // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
 const { recommended } = configs
 
-export const noUnsanitized: ConfigArray = config([recommended])
+export const noUnsanitized = defineConfig([recommended]) satisfies Config[]

--- a/packages/config/src/eslint/base/onlyWarn.ts
+++ b/packages/config/src/eslint/base/onlyWarn.ts
@@ -1,12 +1,13 @@
+import { defineConfig } from 'eslint/config'
 // @ts-expect-error -- untyped module
 import onlyWarnPlugin from 'eslint-plugin-only-warn'
-import { config, type ConfigArray } from 'typescript-eslint'
+import { type Config } from './base.js'
 import { type ESLintPlugin } from './turbo.js'
 
-export const onlyWarn: ConfigArray = config([
+export const onlyWarn = defineConfig([
   {
     plugins: {
       onlyWarn: onlyWarnPlugin as ESLintPlugin,
     },
   },
-])
+]) satisfies Config[]

--- a/packages/config/src/eslint/base/prettier.ts
+++ b/packages/config/src/eslint/base/prettier.ts
@@ -1,8 +1,9 @@
+import { defineConfig } from 'eslint/config'
 import prettierConfig from 'eslint-config-prettier'
 import prettierPluginRecommended from 'eslint-plugin-prettier/recommended'
-import { config, type ConfigArray } from 'typescript-eslint'
+import { type Config } from './base.js'
 
-export const prettier: ConfigArray = config([
+export const prettier = defineConfig([
   prettierConfig,
   prettierPluginRecommended,
   {
@@ -21,4 +22,4 @@ export const prettier: ConfigArray = config([
       ],
     },
   },
-])
+]) satisfies Config[]

--- a/packages/config/src/eslint/base/turbo.ts
+++ b/packages/config/src/eslint/base/turbo.ts
@@ -1,9 +1,10 @@
+import { defineConfig } from 'eslint/config'
 import turboPlugin from 'eslint-plugin-turbo'
-import { config, type ConfigArray } from 'typescript-eslint'
+import { type Config } from './base.js'
 
 export type ESLintPlugin = typeof turboPlugin
 
-export const turbo: ConfigArray = config([
+export const turbo = defineConfig([
   {
     plugins: {
       turbo: turboPlugin,
@@ -12,4 +13,4 @@ export const turbo: ConfigArray = config([
       'turbo/no-undeclared-env-vars': 'warn',
     },
   },
-])
+]) satisfies Config[]

--- a/packages/config/src/eslint/base/typeScript/importX.ts
+++ b/packages/config/src/eslint/base/typeScript/importX.ts
@@ -1,14 +1,15 @@
 import parser from '@typescript-eslint/parser'
+import { defineConfig } from 'eslint/config'
 import { importX as importXPlugin } from 'eslint-plugin-import-x'
-import { config, type ConfigArray } from 'typescript-eslint'
+import { type Config } from '../base.js'
 
 const {
   flatConfigs: { recommended, typescript },
 } = importXPlugin
 
-export const importX: ConfigArray = config([
-  recommended,
-  typescript,
+export const importX = defineConfig([
+  recommended as Config,
+  typescript as Config,
   {
     languageOptions: {
       parser,
@@ -25,4 +26,4 @@ export const importX: ConfigArray = config([
       ],
     },
   },
-])
+]) satisfies Config[]

--- a/packages/config/src/eslint/base/typeScript/typeScript.ts
+++ b/packages/config/src/eslint/base/typeScript/typeScript.ts
@@ -1,9 +1,11 @@
-import { config, configs, type ConfigArray } from 'typescript-eslint'
+import { defineConfig } from 'eslint/config'
+import { configs } from 'typescript-eslint'
+import { type Config } from '../base.js'
 import { importX } from './importX.js'
 
 const { strictTypeChecked, stylisticTypeChecked } = configs
 
-export const typeScript: ConfigArray = config([
+export const typeScript = defineConfig([
   {
     extends: [strictTypeChecked, stylisticTypeChecked],
     ignores: ['**/*.json'],
@@ -15,4 +17,4 @@ export const typeScript: ConfigArray = config([
     },
   },
   ...importX,
-])
+]) satisfies Config[]

--- a/packages/config/src/eslint/next.ts
+++ b/packages/config/src/eslint/next.ts
@@ -1,18 +1,20 @@
 import nextPlugin, { configs } from '@next/eslint-plugin-next'
-import { config, type ConfigArray } from 'typescript-eslint'
+import { type ESLint, type Linter } from 'eslint'
+import { defineConfig } from 'eslint/config'
+import { type Config } from './base/base.js'
 import { reactWithoutBrowserGlobals } from './react/react.js'
 
-export const next: ConfigArray = config([
-  // @ts-expect-error -- `rules` are presumed valid
+type Rules = Partial<Linter.RulesRecord>
+
+export const next = defineConfig([
   ...reactWithoutBrowserGlobals,
   {
     plugins: {
-      '@next/next': nextPlugin,
+      '@next/next': nextPlugin as ESLint.Plugin,
     },
-    // @ts-expect-error -- `rules` are presumed valid
     rules: {
-      ...configs.recommended.rules,
-      ...configs['core-web-vitals'].rules,
+      ...(configs.recommended.rules as Rules),
+      ...(configs['core-web-vitals'].rules as Rules),
     },
   },
-])
+]) satisfies Config[]

--- a/packages/config/src/eslint/react/hooks.ts
+++ b/packages/config/src/eslint/react/hooks.ts
@@ -1,8 +1,9 @@
+import { defineConfig } from 'eslint/config'
 // eslint-disable-next-line import-x/default
 import hooksPlugin, { configs } from 'eslint-plugin-react-hooks'
-import { config, type ConfigArray } from 'typescript-eslint'
+import { type Config } from '../base/base.js'
 
-export const hooks: ConfigArray = config([
+export const hooks = defineConfig([
   {
     plugins: {
       'react-hooks': hooksPlugin,
@@ -10,4 +11,4 @@ export const hooks: ConfigArray = config([
     rules: configs.recommended.rules,
     settings: { react: { version: 'detect' } },
   },
-])
+]) satisfies Config[]

--- a/packages/config/src/eslint/react/react.ts
+++ b/packages/config/src/eslint/react/react.ts
@@ -1,7 +1,7 @@
+import { defineConfig } from 'eslint/config'
 import { configs, type ReactFlatConfig } from 'eslint-plugin-react'
 import { browser, serviceworker } from 'globals'
-import { config as tseslintConfig, type ConfigArray } from 'typescript-eslint'
-import { base } from '../base/base.js'
+import { base, type Config } from '../base/base.js'
 import { hooks } from './hooks.js'
 
 const defaultRecommended = {
@@ -12,8 +12,8 @@ const defaultRecommended = {
   } = configs,
   { languageOptions }: ReactFlatConfig | typeof defaultRecommended = recommended
 
-function config(browserGlobals: boolean): ConfigArray {
-  return tseslintConfig([
+function config(browserGlobals: boolean): Config[] {
+  return defineConfig([
     ...base,
     recommended,
     jsxRuntime,
@@ -27,8 +27,8 @@ function config(browserGlobals: boolean): ConfigArray {
       },
     },
     ...hooks,
-  ])
+  ]) satisfies Config[]
 }
 
-export const react: ConfigArray = config(true)
-export const reactWithoutBrowserGlobals: ConfigArray = config(false)
+export const react: Config[] = config(true)
+export const reactWithoutBrowserGlobals: Config[] = config(false)


### PR DESCRIPTION
ESLint `defineConfig` replaces all deprecated `typescript-eslint` config helpers, enabling support for future versions.