### PR TITLE
ESLint `Plugin` unified type

### DIFF
--- a/packages/config/src/eslint/base/base.ts
+++ b/packages/config/src/eslint/base/base.ts
@@ -1,4 +1,4 @@
-import { type Linter } from 'eslint'
+import { type ESLint, type Linter } from 'eslint'
 import { defineConfig } from 'eslint/config'
 import { globalIgnores } from './globalIgnores.js'
 import { javaScript } from './javaScript.js'
@@ -10,6 +10,7 @@ import { turbo } from './turbo.js'
 import { typeScript } from './typeScript/typeScript.js'
 
 export type Config = Linter.Config
+export type Plugin = ESLint.Plugin
 
 export const base = defineConfig([
   ...javaScript,

--- a/packages/config/src/eslint/base/onlyWarn.ts
+++ b/packages/config/src/eslint/base/onlyWarn.ts
@@ -1,13 +1,12 @@
 import { defineConfig } from 'eslint/config'
 // @ts-expect-error -- untyped module
 import onlyWarnPlugin from 'eslint-plugin-only-warn'
-import { type Config } from './base.js'
-import { type ESLintPlugin } from './turbo.js'
+import { type Config, type Plugin } from './base.js'
 
 export const onlyWarn = defineConfig([
   {
     plugins: {
-      onlyWarn: onlyWarnPlugin as ESLintPlugin,
+      onlyWarn: onlyWarnPlugin as Plugin,
     },
   },
 ]) satisfies Config[]

--- a/packages/config/src/eslint/base/turbo.ts
+++ b/packages/config/src/eslint/base/turbo.ts
@@ -2,8 +2,6 @@ import { defineConfig } from 'eslint/config'
 import turboPlugin from 'eslint-plugin-turbo'
 import { type Config } from './base.js'
 
-export type ESLintPlugin = typeof turboPlugin
-
 export const turbo = defineConfig([
   {
     plugins: {

--- a/packages/config/src/eslint/next.ts
+++ b/packages/config/src/eslint/next.ts
@@ -1,7 +1,7 @@
 import nextPlugin, { configs } from '@next/eslint-plugin-next'
-import { type ESLint, type Linter } from 'eslint'
+import { type Linter } from 'eslint'
 import { defineConfig } from 'eslint/config'
-import { type Config } from './base/base.js'
+import { type Config, type Plugin } from './base/base.js'
 import { reactWithoutBrowserGlobals } from './react/react.js'
 
 type Rules = Partial<Linter.RulesRecord>
@@ -10,7 +10,7 @@ export const next = defineConfig([
   ...reactWithoutBrowserGlobals,
   {
     plugins: {
-      '@next/next': nextPlugin as ESLint.Plugin,
+      '@next/next': nextPlugin as Plugin,
     },
     rules: {
       ...(configs.recommended.rules as Rules),


### PR DESCRIPTION
The ESLint `Plugin` unified type replaces a `typeof` definition.