### PR TITLE
Superfluous `@mui/material-nextjs` app dependency removal

### DIFF
--- a/apps/demo-mui/package.json
+++ b/apps/demo-mui/package.json
@@ -17,7 +17,6 @@
     "@emotion/styled": "^11.14.1",
     "@mui/icons-material": "^7.3.2",
     "@mui/material": "^7.3.2",
-    "@mui/material-nextjs": "^7.3.2",
     "@repo/mui": "workspace:*",
     "next": "^15.5.3",
     "react": "^19.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -66,9 +66,6 @@ importers:
       '@mui/material':
         specifier: ^7.3.2
         version: 7.3.2(@emotion/react@11.14.0(@types/react@19.1.13)(react@19.1.1))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.1.13)(react@19.1.1))(@types/react@19.1.13)(react@19.1.1))(@types/react@19.1.13)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
-      '@mui/material-nextjs':
-        specifier: ^7.3.2
-        version: 7.3.2(@emotion/cache@11.14.0)(@emotion/react@11.14.0(@types/react@19.1.13)(react@19.1.1))(@types/react@19.1.13)(next@15.5.3(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(react@19.1.1)
       '@repo/mui':
         specifier: workspace:*
         version: link:../../packages/mui


### PR DESCRIPTION
Superfluous `@mui/material-nextjs` dependency removed from `demo-mui`,