### PR TITLE
`eslint-plugin-jest` configuration

### DIFF
--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -25,6 +25,7 @@
     "eslint-config-prettier": "^10.1.8",
     "eslint-import-resolver-typescript": "^4.4.4",
     "eslint-plugin-import-x": "^4.16.1",
+    "eslint-plugin-jest": "^29.0.1",
     "eslint-plugin-jsonc": "^2.20.1",
     "eslint-plugin-no-unsanitized": "^4.1.4",
     "eslint-plugin-only-warn": "^1.1.0",

--- a/packages/config/src/eslint/base/base.ts
+++ b/packages/config/src/eslint/base/base.ts
@@ -3,6 +3,7 @@ import { defineConfig } from 'eslint/config'
 
 import { globalIgnores } from './globalIgnores.js'
 import { javaScript } from './javaScript.js'
+import { jest } from './jest.js'
 import { json } from './json.js'
 import { noUnsanitized } from './noUnsanitized.js'
 import { onlyWarn } from './onlyWarn.js'
@@ -19,6 +20,7 @@ export const base = defineConfig([
   ...javaScript,
   ...typeScript,
   ...noUnsanitized,
+  ...jest,
   ...json,
   ...turbo,
   ...perfectionist,

--- a/packages/config/src/eslint/base/jest.ts
+++ b/packages/config/src/eslint/base/jest.ts
@@ -1,0 +1,17 @@
+import { configs } from 'eslint-plugin-jest'
+import { defineConfig } from 'eslint/config'
+
+import { type Config } from './base.js'
+
+const {
+  'flat/recommended': recommended,
+  'flat/style': style,
+}: Record<`flat/${'all' | 'recommended' | 'style'}`, Config> = configs
+
+export const jest = defineConfig([
+  {
+    files: ['**/*.test.ts?(x)'],
+    ...recommended,
+    ...style,
+  },
+]) satisfies Config[]

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -130,6 +130,9 @@ importers:
       eslint-plugin-import-x:
         specifier: ^4.16.1
         version: 4.16.1(@typescript-eslint/utils@8.44.0(eslint@9.36.0(jiti@2.5.1))(typescript@5.9.2))(eslint@9.36.0(jiti@2.5.1))
+      eslint-plugin-jest:
+        specifier: ^29.0.1
+        version: 29.0.1(@typescript-eslint/eslint-plugin@8.44.0(@typescript-eslint/parser@8.44.0(eslint@9.36.0(jiti@2.5.1))(typescript@5.9.2))(eslint@9.36.0(jiti@2.5.1))(typescript@5.9.2))(eslint@9.36.0(jiti@2.5.1))(typescript@5.9.2)
       eslint-plugin-jsonc:
         specifier: ^2.20.1
         version: 2.20.1(eslint@9.36.0(jiti@2.5.1))
@@ -1251,6 +1254,19 @@ packages:
       '@typescript-eslint/utils':
         optional: true
       eslint-import-resolver-node:
+        optional: true
+
+  eslint-plugin-jest@29.0.1:
+    resolution: {integrity: sha512-EE44T0OSMCeXhDrrdsbKAhprobKkPtJTbQz5yEktysNpHeDZTAL1SfDTNKmcFfJkY6yrQLtTKZALrD3j/Gpmiw==}
+    engines: {node: ^20.12.0 || ^22.0.0 || >=24.0.0}
+    peerDependencies:
+      '@typescript-eslint/eslint-plugin': ^8.0.0
+      eslint: ^8.57.0 || ^9.0.0
+      jest: '*'
+    peerDependenciesMeta:
+      '@typescript-eslint/eslint-plugin':
+        optional: true
+      jest:
         optional: true
 
   eslint-plugin-jsonc@2.20.1:
@@ -3207,6 +3223,16 @@ snapshots:
       '@typescript-eslint/utils': 8.44.0(eslint@9.36.0(jiti@2.5.1))(typescript@5.9.2)
     transitivePeerDependencies:
       - supports-color
+
+  eslint-plugin-jest@29.0.1(@typescript-eslint/eslint-plugin@8.44.0(@typescript-eslint/parser@8.44.0(eslint@9.36.0(jiti@2.5.1))(typescript@5.9.2))(eslint@9.36.0(jiti@2.5.1))(typescript@5.9.2))(eslint@9.36.0(jiti@2.5.1))(typescript@5.9.2):
+    dependencies:
+      '@typescript-eslint/utils': 8.44.0(eslint@9.36.0(jiti@2.5.1))(typescript@5.9.2)
+      eslint: 9.36.0(jiti@2.5.1)
+    optionalDependencies:
+      '@typescript-eslint/eslint-plugin': 8.44.0(@typescript-eslint/parser@8.44.0(eslint@9.36.0(jiti@2.5.1))(typescript@5.9.2))(eslint@9.36.0(jiti@2.5.1))(typescript@5.9.2)
+    transitivePeerDependencies:
+      - supports-color
+      - typescript
 
   eslint-plugin-jsonc@2.20.1(eslint@9.36.0(jiti@2.5.1)):
     dependencies:


### PR DESCRIPTION
Configures `eslint-plugin-jest` to ensure future ESLint compatibility with Jest.