### PR TITLE
`pnpm@10.33.3` patch

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   "devDependencies": {
     "turbo": "^2.8.12"
   },
-  "packageManager": "pnpm@10.33.2",
+  "packageManager": "pnpm@10.33.3",
   "engines": {
     "node": "^24.15.0",
     "npm": "^11.13.0"


### PR DESCRIPTION
Patches `pnpm` package manager to `pnpm@10.33.3` (latest stable version).