### PR TITLE
`@eslint-react` configuration extends `base` ESLint configuration

### DIFF
--- a/packages/config-eslint-typescript/src/eslint/base/jsonc.ts
+++ b/packages/config-eslint-typescript/src/eslint/base/jsonc.ts
@@ -10,11 +10,7 @@ const {
   } = configs,
   config = defineConfig([
     {
-      extends: [
-        base as Config,
-        recommendedWithJSON as Config,
-        prettier as Config,
-      ],
+      extends: [base, recommendedWithJSON, prettier],
       files: ['**/*.json'],
     },
   ]) satisfies Config[]

--- a/packages/config-eslint-typescript/src/eslint/base/turbo.ts
+++ b/packages/config-eslint-typescript/src/eslint/base/turbo.ts
@@ -1,12 +1,12 @@
 import turboPlugin from 'eslint-plugin-turbo'
 import { defineConfig } from 'eslint/config'
 
-import { type Config, type Plugin } from './base.js'
+import { type Config } from './base.js'
 
 const config = defineConfig([
   {
     plugins: {
-      turbo: turboPlugin as Plugin,
+      turbo: turboPlugin,
     },
     rules: {
       'turbo/no-undeclared-env-vars': 'warn',

--- a/packages/config-eslint-typescript/src/eslint/base/typeScript/importX.ts
+++ b/packages/config-eslint-typescript/src/eslint/base/typeScript/importX.ts
@@ -8,8 +8,8 @@ const {
     flatConfigs: { recommended, typescript },
   } = importXPlugin,
   config = defineConfig([
-    recommended as Config,
-    typescript as Config,
+    recommended,
+    typescript,
     {
       languageOptions: {
         parser,

--- a/packages/config-eslint-typescript/src/eslint/next.ts
+++ b/packages/config-eslint-typescript/src/eslint/next.ts
@@ -1,14 +1,14 @@
 import nextPlugin, { configs } from '@next/eslint-plugin-next'
 import { defineConfig } from 'eslint/config'
 
-import { type Config, type Plugin, type Rules } from './base/base.js'
+import { type Config, type Rules } from './base/base.js'
 import { reactWithoutBrowserGlobals } from './react.js'
 
 const config = defineConfig([
   ...reactWithoutBrowserGlobals,
   {
     plugins: {
-      '@next/next': nextPlugin as Plugin,
+      '@next/next': nextPlugin,
     },
     rules: {
       ...(configs.recommended.rules as Rules),

--- a/packages/config-eslint-typescript/src/eslint/react.ts
+++ b/packages/config-eslint-typescript/src/eslint/react.ts
@@ -4,12 +4,13 @@ import { defineConfig } from 'eslint/config'
 import { browser, serviceworker } from 'globals'
 import { parser, configs as tsConfigs } from 'typescript-eslint'
 
-import { type Config } from './base/base.js'
+import { type Config, base } from './base/base.js'
 
 function config(browserGlobals: boolean): Config[] {
   return defineConfig([
     {
       extends: [
+        base,
         jsConfigs.recommended,
         tsConfigs.recommended,
         eslintReact.configs['recommended-typescript'],

--- a/packages/fixed-width/src/bits64/uInt.test.ts
+++ b/packages/fixed-width/src/bits64/uInt.test.ts
@@ -43,7 +43,7 @@ describe('UInt64', (): void => {
 
   describe('negative sign bigint|number', (): void => {
     it.each([
-      { expected: max64, n: -1 as number, name: '-1 (number)' },
+      { expected: max64, n: -1, name: '-1 (number)' },
       { expected: max64, n: -1, name: '-1 (number literal)' },
       { expected: 0n, n: -over64, name: '-(2^64)' },
       { expected: max64 - 6n, n: -(over64 + 7n), name: '-(2^64 + 7n)' },

--- a/packages/mui/src/components/Page/Copyright.tsx
+++ b/packages/mui/src/components/Page/Copyright.tsx
@@ -1,3 +1,5 @@
+'use client'
+
 import MuiLink from '@mui/material/Link'
 import { type ReactElement, useState } from 'react'
 

--- a/packages/mui/src/components/Page/Copyright.tsx
+++ b/packages/mui/src/components/Page/Copyright.tsx
@@ -6,7 +6,7 @@ import { type ReactElement, useState } from 'react'
 import { Footer } from '../Typography/Footer'
 
 export function Copyright(): ReactElement {
-  const [fullYear] = useState((): string => String(new Date().getFullYear()))
+  const [localYear] = useState((): string => String(new Date().getFullYear()))
 
   return (
     <Footer>
@@ -14,7 +14,7 @@ export function Copyright(): ReactElement {
       <MuiLink color="inherit" href="https://mui.com/">
         Your Website
       </MuiLink>
-      {` ${fullYear}.`}
+      {` ${localYear}.`}
     </Footer>
   )
 }

--- a/packages/mui/src/components/Page/Copyright.tsx
+++ b/packages/mui/src/components/Page/Copyright.tsx
@@ -1,16 +1,18 @@
 import MuiLink from '@mui/material/Link'
-import { type ReactElement } from 'react'
+import { type ReactElement, useState } from 'react'
 
 import { Footer } from '../Typography/Footer'
 
 export function Copyright(): ReactElement {
+  const [fullYear] = useState((): string => String(new Date().getFullYear()))
+
   return (
     <Footer>
       {'Copyright © '}
       <MuiLink color="inherit" href="https://mui.com/">
         Your Website
-      </MuiLink>{' '}
-      {new Date().getFullYear()}.
+      </MuiLink>
+      {` ${fullYear}.`}
     </Footer>
   )
 }


### PR DESCRIPTION
The `@eslint-react` configuration now correctly extends the `base` ESLint configuration as intended. Minor quality updates include ESLint compliance.