### PR TITLE
`AppRouterCacheProvider` imports from Next.js v16 (current), replacing outdated v15 import

### DIFF
--- a/packages/mui/src/components/MuiProviders.tsx
+++ b/packages/mui/src/components/MuiProviders.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { AppRouterCacheProvider } from '@mui/material-nextjs/v15-appRouter'
+import { AppRouterCacheProvider } from '@mui/material-nextjs/v16-appRouter'
 import CssBaseline from '@mui/material/CssBaseline'
 import {
   type Theme,


### PR DESCRIPTION
In `packages/mui/src/components/MuiProviders.tsx`, `AppRouterCacheProvider` imports from Next.js v16 (current), replacing the outdated v15 import.